### PR TITLE
Finish change theme feature ** Successfully ** ✅.

### DIFF
--- a/lib/core/helpers/shared_prefrence.dart
+++ b/lib/core/helpers/shared_prefrence.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SharedPreferenceUtils {
+  static late SharedPreferences prefs;
+
+  static init() async {
+    prefs = await SharedPreferences.getInstance();
+  }
+
+  static Future<bool> saveData({required String key, required dynamic value}) {
+    if (value is int) {
+      return prefs.setInt(key, value);
+    } else if (value is String) {
+      return prefs.setString(key, value);
+    } else if (value is double) {
+      return prefs.setDouble(key, value);
+    } else if (value is ThemeMode) {
+      /// for theme mode
+      return prefs.setString(key, value.name);
+    } else if (value is bool) {
+      return prefs.setBool(key, value);
+    } else {
+      throw Exception("Unsupported value type");
+    }
+  }
+
+  static dynamic getData({required String key}) {
+    return prefs.get(key);
+  }
+
+  static Future<bool> removeData({required String key}) async {
+    return await prefs.remove(key);
+  }
+
+  /// for theme mode
+  static ThemeMode getThemeMode(String key) {
+    String? value = getData(key: key);
+
+    switch (value) {
+      case 'light':
+        return ThemeMode.light;
+      case 'dark':
+        return ThemeMode.dark;
+      case 'system':
+        return ThemeMode.system;
+      default:
+        return ThemeMode.light;
+    }
+  }
+}

--- a/lib/core/utils/app_theme.dart
+++ b/lib/core/utils/app_theme.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'color_manager.dart';
 
 class AppStyle {
-  static bool isDark = false;
   static ThemeData lightTheme = ThemeData(
     fontFamily: "Inter",
     scaffoldBackgroundColor: ColorManager.background,

--- a/lib/core/utils/strings_manager.dart
+++ b/lib/core/utils/strings_manager.dart
@@ -67,4 +67,5 @@ class AppStrings {
       "take_the_hassle_out_of_organizing_events";
   static const String makeEveryEventMemorable = "make_every_event_memorable";
   static const String letsStart = "lets_start";
+  static const String currentThemeMode = "theme";
 }

--- a/lib/features/start_screen/widgets/theme_toggle.dart
+++ b/lib/features/start_screen/widgets/theme_toggle.dart
@@ -1,7 +1,11 @@
 import 'package:animated_toggle_switch/animated_toggle_switch.dart';
+import 'package:evently_app/core/utils/strings_manager.dart';
+import 'package:evently_app/providers/theme_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/svg.dart';
+import 'package:provider/provider.dart';
 
+import '../../../core/helpers/shared_prefrence.dart';
 import '../../../core/utils/asset_manager.dart';
 
 class ThemeToggle extends StatefulWidget {
@@ -12,16 +16,27 @@ class ThemeToggle extends StatefulWidget {
 }
 
 class _ThemeToggleState extends State<ThemeToggle> {
-  int currentValue = 0;
+  late ThemeProvider themeProvider;
 
   @override
   Widget build(BuildContext context) {
+    themeProvider = Provider.of<ThemeProvider>(context);
+    int currentValue = themeProvider.currentTheme == ThemeMode.light ? 0 : 1;
     return AnimatedToggleSwitch<int>.rolling(
       current: currentValue,
       values: [0, 1],
       onChanged: (newValue) {
         setState(() {
           currentValue = newValue;
+          if (currentValue == 0) {
+            themeProvider.changeThemeMode(ThemeMode.light);
+            SharedPreferenceUtils.saveData(
+                key: AppStrings.currentThemeMode, value: ThemeMode.light);
+          } else {
+            themeProvider.changeThemeMode(ThemeMode.dark);
+            SharedPreferenceUtils.saveData(
+                key: AppStrings.currentThemeMode, value: ThemeMode.dark);
+          }
         });
       },
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,14 +1,18 @@
 import 'package:easy_localization/easy_localization.dart';
+import 'package:evently_app/core/helpers/shared_prefrence.dart';
 import 'package:evently_app/core/utils/app_routes.dart';
 import 'package:evently_app/core/utils/app_theme.dart';
+import 'package:evently_app/providers/theme_provider.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:provider/provider.dart';
 
 import 'features/start_screen/screen/start_screen.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await EasyLocalization.ensureInitialized();
+  await SharedPreferenceUtils.init();
   runApp(EasyLocalization(
       supportedLocales: [Locale('en'), Locale('ar')],
       path: 'assets/translations',
@@ -17,7 +21,9 @@ void main() async {
       // first time open language
       saveLocale: true,
       // default is true already but this only for clarity
-      child: MyApp()));
+      child: ChangeNotifierProvider(
+          create: (_) => ThemeProvider(),
+          child: MyApp())));
 }
 
 class MyApp extends StatelessWidget {
@@ -25,6 +31,7 @@ class MyApp extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    ThemeProvider themeProvider = Provider.of<ThemeProvider>(context);
     return ScreenUtilInit(
       designSize: const Size(393, 841),
       minTextAdapt: true,
@@ -37,7 +44,7 @@ class MyApp extends StatelessWidget {
           debugShowCheckedModeBanner: false,
           theme: AppStyle.lightTheme,
           darkTheme: AppStyle.darkTheme,
-          themeMode: AppStyle.isDark ? ThemeMode.dark : ThemeMode.light,
+          themeMode: themeProvider.currentTheme,
           routes: {AppRoutes.startScreen: (_) => const StartScreen()},
           initialRoute: AppRoutes.startScreen,
         );

--- a/lib/providers/theme_provider.dart
+++ b/lib/providers/theme_provider.dart
@@ -1,0 +1,17 @@
+import 'package:evently_app/core/helpers/shared_prefrence.dart';
+import 'package:evently_app/core/utils/strings_manager.dart';
+import 'package:flutter/material.dart';
+
+class ThemeProvider extends ChangeNotifier {
+  ThemeMode currentTheme = SharedPreferenceUtils.getThemeMode(
+    AppStrings.currentThemeMode,
+  );
+
+  void changeThemeMode(ThemeMode newThemeMode) {
+    if (newThemeMode == currentTheme) {
+      return;
+    }
+    currentTheme = newThemeMode;
+    notifyListeners();
+  }
+}


### PR DESCRIPTION
- Finish change theme feature by using provider as state management and use shared pref to save last theme when user restart the app✅.
- Add shared preference helper file✅.




![image](https://github.com/user-attachments/assets/684953ff-bc6e-448b-a708-3dbf739c46e7)

![image](https://github.com/user-attachments/assets/3416e58e-2307-4e17-93d3-b056adb9cbe8)
